### PR TITLE
Fix reading Unique IDs on CC430

### DIFF
--- a/stack/framework/hal/chips/cc430/cc430_system.c
+++ b/stack/framework/hal/chips/cc430/cc430_system.c
@@ -67,23 +67,14 @@ uint64_t hw_get_unique_id()
     TLV_getInfo(TLV_TAG_DIERECORD,
         0,
         &bDieRecord_bytes,
-        (unsigned int **)&pDIEREC
+        (uint16_t **)&pDIEREC
         );
 
-    unsigned char tagId[8];
-    unsigned char* pointer = (unsigned char*) &(pDIEREC->wafer_id);
-    tagId[0] = pointer[3];
-    tagId[1] = pointer[2];
-    tagId[2] = pointer[1];
-    tagId[3] = pointer[0];
-    pointer = (unsigned char*) &(pDIEREC->die_x_position);
-    tagId[4] = pointer[1];
-    tagId[5] = pointer[0];
+    uint64_t unique_id =  (pDIEREC->wafer_id       & 0xFF)
+                       | ((pDIEREC->die_x_position & 0x0F) << 0x8)
+                       | ((pDIEREC->die_y_position & 0x0F) << 0xC);
 
-    pointer = (unsigned char*) &(pDIEREC->die_y_position);
-    tagId[6] = pointer[1];
-    tagId[7] = pointer[0];
-    return (uint64_t) tagId;
+    return unique_id;
 }
 
 void hw_busy_wait(int16_t microseconds)


### PR DESCRIPTION
Earlier, IDs were put to char array, which was unaccessable after exiting function scope. Also, 8 bits for ID wasn't enough, I have extended it to 16 bits.