### PR TITLE
efm32hg uart fix and spi addition

### DIFF
--- a/stack/framework/hal/chips/efm32hg/efm32hg_spi.c
+++ b/stack/framework/hal/chips/efm32hg/efm32hg_spi.c
@@ -41,8 +41,8 @@
 
 #include "platform.h"
 
-#define USARTS    1
-#define LOCATIONS 1
+#define USARTS    2
+#define LOCATIONS 7
 
 typedef struct {
   uint32_t location;
@@ -51,17 +51,97 @@ typedef struct {
   pin_id_t clk;
 } spi_pins_t;
 
+#define UNDEFINED_LOCATION {                      \
+  .location = 0,                                  \
+  .mosi       = { .port = 0,         .pin =  0 },   \
+  .miso       = { .port = 0,         .pin =  0 },   \
+  .clk        = { .port = 0,         .pin =  0 }    \
+}
+
 // TODO to be completed with all documented locations
 static spi_pins_t location[USARTS][LOCATIONS] = {
   {
-    // USART 0
-    {
-      .location = USART_ROUTE_LOCATION_LOC0,
-      .mosi     = { .port = gpioPortE, .pin = 10 },
-      .miso     = { .port = gpioPortE, .pin = 11 },
-      .clk      = { .port = gpioPortE, .pin = 12 }
+    // USART 0 LOCATION 0
+	{
+	  .location = USART_ROUTE_LOCATION_LOC0,
+	  .mosi     = { .port = gpioPortE, .pin = 10 },
+	  .miso     = { .port = gpioPortE, .pin = 11 },
+	  .clk      = { .port = gpioPortE, .pin = 12 }
+	},
+    // no USART 0 LOCATION 1
+	UNDEFINED_LOCATION,
+	// incomplete USART 0 LOCATION 2 (no MOSI)
+	UNDEFINED_LOCATION,
+	// USART 0 LOCATION 3
+	{
+	  .location = USART_ROUTE_LOCATION_LOC3,
+	  .mosi     = { .port = gpioPortE, .pin = 13 },
+	  .miso     = { .port = gpioPortE, .pin = 12 },
+	  .clk      = { .port = gpioPortC, .pin = 15 }
+	},
+	// USART 0 LOCATION 4
+	{
+	  .location = USART_ROUTE_LOCATION_LOC4,
+	  .mosi     = { .port = gpioPortB, .pin = 7 },
+	  .miso     = { .port = gpioPortB, .pin = 8 },
+	  .clk      = { .port = gpioPortB, .pin = 13 }
+	},
+	// USART 0 LOCATION 5
+	{
+	  .location = USART_ROUTE_LOCATION_LOC5,
+	  .mosi     = { .port = gpioPortC, .pin = 0 },
+	  .miso     = { .port = gpioPortC, .pin = 1 },
+	  .clk      = { .port = gpioPortB, .pin = 13 }
+	},
+	// USART 0 LOCATION 6
+	{
+	  .location = USART_ROUTE_LOCATION_LOC6,
+	  .mosi     = { .port = gpioPortC, .pin = 0 },
+	  .miso     = { .port = gpioPortC, .pin = 1 },
+	  .clk      = { .port = gpioPortE, .pin = 12 }
+	}
+  },
+  {
+    // USART 1 LOCATION 0
+  	{
+  	  .location = USART_ROUTE_LOCATION_LOC0,
+  	  .mosi     = { .port = gpioPortC, .pin = 0 },
+  	  .miso     = { .port = gpioPortC, .pin = 1 },
+  	  .clk      = { .port = gpioPortB, .pin = 7 }
+  	},
+    // no USART 1 LOCATION 1
+  	UNDEFINED_LOCATION,
+  	// USART 1 LOCATION 2
+  	{
+	  .location = USART_ROUTE_LOCATION_LOC2,
+	  .mosi     = { .port = gpioPortD, .pin = 7 },
+	  .miso     = { .port = gpioPortD, .pin = 6 },
+	  .clk      = { .port = gpioPortF, .pin = 0 }
+  	},
+  	// USART 1 LOCATION 3
+  	{
+  	  .location = USART_ROUTE_LOCATION_LOC3,
+  	  .mosi     = { .port = gpioPortD, .pin = 7 },
+  	  .miso     = { .port = gpioPortD, .pin = 6 },
+  	  .clk      = { .port = gpioPortC, .pin = 15 }
+  	},
+  	// USART 1 LOCATION 4
+  	{
+  	  .location = USART_ROUTE_LOCATION_LOC4,
+  	  .mosi     = { .port = gpioPortF, .pin = 2 },
+  	  .miso     = { .port = gpioPortA, .pin = 0 },
+  	  .clk      = { .port = gpioPortB, .pin = 11 }
+  	},
+  	// USART 1 LOCATION 5
+  	{
+  	  .location = USART_ROUTE_LOCATION_LOC5,
+  	  .mosi     = { .port = gpioPortC, .pin = 1 },
+  	  .miso     = { .port = gpioPortC, .pin = 2 },
+  	  .clk      = { .port = gpioPortC, .pin = 3 }
+  	},
+    // no USART 1 LOCATION 6
+    UNDEFINED_LOCATION
     }
-  }
 };
 
 typedef struct {
@@ -74,6 +154,10 @@ static spi_usart_t usart[USARTS] = {
   {
     .channel = USART0,
     .clock   = cmuClock_USART0
+  },
+  {
+     .channel = USART1,
+     .clock   = cmuClock_USART1
   }
 };
   

--- a/stack/framework/hal/chips/efm32hg/efm32hg_uart.c
+++ b/stack/framework/hal/chips/efm32hg/efm32hg_uart.c
@@ -84,13 +84,13 @@ static uart_pins_t location[UARTS][LOCATIONS] = {
 		},
 		{
 		  .location = USART_ROUTE_LOCATION_LOC5,
-		  .tx       = { .port = gpioPortC, .pin =  1 },
-		  .rx       = { .port = gpioPortC, .pin =  0 }
+		  .tx       = { .port = gpioPortC, .pin =  0 },
+		  .rx       = { .port = gpioPortC, .pin =  1 }
 		},
 		{
-		  .location = USART_ROUTE_LOCATION_LOC5,
-		  .tx       = { .port = gpioPortC, .pin =  1 },
-		  .rx       = { .port = gpioPortC, .pin =  0 }
+		  .location = USART_ROUTE_LOCATION_LOC6,
+		  .tx       = { .port = gpioPortC, .pin =  0 },
+		  .rx       = { .port = gpioPortC, .pin =  1 }
 		}
 	},
 	{


### PR DESCRIPTION
Fix for efm32hg_uart.c wrong pin numbers for location 5 and 6 and location 5 double assigned
Added extra location to efm32hg_spi.