### PR TITLE
fix fifo hang problem

### DIFF
--- a/stack/framework/components/fifo/fifo.c
+++ b/stack/framework/components/fifo/fifo.c
@@ -37,7 +37,7 @@ error_t fifo_put(fifo_t *fifo, uint8_t *data, uint16_t len)
     if(fifo->tail_idx + len <= fifo->max_size)
     {
         memcpy(fifo->buffer + fifo->tail_idx, data, len);
-        fifo->tail_idx += len;
+        fifo->tail_idx = (fifo->tail_idx + len) % fifo->max_size;
         return SUCCESS;
     }
 


### PR DESCRIPTION
When using the fifo in my application (LoRa) I push and pop 1 byte at a time to the fifo. After some time of working (sometimes minutes sometimes hours) the fifo blocked the application by keeping fifo->tail_idx on the fifo->max_size. I fixed it with this change but other possible changes can fix this issue too (e.g. changing the if >= to < and provide an else case)
The issue itself seems serious as it can block the communication of an application. Probably it is not previously seen in other applications as these do not pop 1 byte at a time and are less likely to trigger this situation of fifo->tail_idx+ len = fifo->max_size. However, it is s till possible and obviously important to fix.
