### PR TITLE
New foreground scan policy for the responder

### DIFF
--- a/stack/modules/d7ap/d7anp.c
+++ b/stack/modules/d7ap/d7anp.c
@@ -135,6 +135,14 @@ void d7anp_tx_foreground_frame(packet_t* packet, bool should_include_origin_temp
 
     packet->d7anp_ctrl.origin_addressee_ctrl_access_class = packet->d7anp_addressee->ctrl.access_class; // TODO validate
 
+    // In case of response, check if the response period is not expired before calling dll API
+    if ((packet->request == false) && (d7atp_is_response_period_expired()))
+    {
+        d7atp_cancel_response_period_timeout_handler();
+        d7atp_signal_transaction_response_period_elapsed();
+        return;
+    }
+
     switch_state(D7ANP_STATE_TRANSMIT);
     dll_tx_frame(packet, access_profile);
 }

--- a/stack/modules/d7ap/d7anp.h
+++ b/stack/modules/d7ap/d7anp.h
@@ -82,5 +82,7 @@ void d7anp_signal_packet_csma_ca_insertion_completed(bool succeeded);
 void d7anp_signal_packet_transmitted(packet_t* packet);
 void d7anp_process_received_packet(packet_t* packet);
 uint8_t d7anp_addressee_id_length(id_type_t);
+void d7anp_start_responder_foreground_scan();
+void d7anp_stop_responder_foreground_scan();
 
 #endif /* D7ANP_H_ */

--- a/stack/modules/d7ap/d7asp.c
+++ b/stack/modules/d7ap/d7asp.c
@@ -59,6 +59,9 @@ static packet_t* NGDEF(_current_request_packet);
 static uint8_t NGDEF(_single_request_retry_limit);
 #define single_request_retry_limit NG(_single_request_retry_limit)
 
+static packet_t* NGDEF(_current_response_packet);
+#define current_response_packet NG(_current_response_packet)
+
 static d7asp_init_args_t* NGDEF(_d7asp_init_args);
 #define d7asp_init_args NG(_d7asp_init_args)
 
@@ -150,8 +153,6 @@ static void flush_fifos()
     // TODO calculate D7ANP timeout (and update during transaction lifetime) (based on Tc, channel, cs, payload size, # msgs, # retries)
     d7atp_start_dialog(fifo.token, current_request_id, true, current_request_packet, &fifo.config.qos);
 }
-
-
 
 // TODO document state diagram
 static void switch_state(state_t new_state)
@@ -351,6 +352,8 @@ bool d7asp_process_received_packet(packet_t* packet)
             goto discard_request; // no need to respond, clean up
 
         DPRINT("Sending response");
+
+        current_response_packet = packet;
         d7atp_respond_dialog(packet);
         return true;
     }
@@ -369,8 +372,11 @@ void d7asp_signal_packet_transmitted(packet_t *packet)
 
     if(state == D7ASP_STATE_SLAVE || state == D7ASP_STATE_SLAVE_PENDING_MASTER)
     {
+        assert(current_response_packet == packet);
+
         // when in slave session we can immediately cleanup the transmitted response.
         // requests (in master sessions) will be cleanup upon termination of the dialog.
+        current_response_packet = NULL;
         packet_queue_free_packet(packet);
     }
 }
@@ -391,20 +397,18 @@ static void on_request_completed()
         packet_queue_free_packet(current_request_packet);
     }
 
-
     sched_post_task(&flush_fifos); // continue flushing until all request handled ...
 }
 
 void d7asp_signal_packet_csma_ca_insertion_completed(bool succeeded)
 {
-    if(state == D7ASP_STATE_MASTER) // TODO only relevant for master sessions?
+    if(state == D7ASP_STATE_MASTER)
     {
         if(!succeeded)
         {
             on_request_completed();
             return;
         }
-
         // for the lowest QoS level the packet is ack-ed when CSMA/CA process succeeded
         if(fifo.config.qos.qos_resp_mode == SESSION_RESP_MODE_NO)
         {
@@ -412,17 +416,35 @@ void d7asp_signal_packet_csma_ca_insertion_completed(bool succeeded)
             bitmap_set(fifo.success_bitmap, current_request_id);
         }
     }
+    else if ((!succeeded) && ((state == D7ASP_STATE_SLAVE) ||
+                (state == D7ASP_STATE_SLAVE_PENDING_MASTER)))
+    {
+        packet_queue_free_packet(current_response_packet);
+        current_response_packet = NULL;
+    }
 }
 
 void d7asp_signal_transaction_response_period_elapsed()
 {
     if(state == D7ASP_STATE_MASTER)
         on_request_completed();
-    else if(state == D7ASP_STATE_SLAVE)
-        switch_state(D7ASP_STATE_IDLE);
-    else if(state == D7ASP_STATE_SLAVE_PENDING_MASTER)
+    else if((state == D7ASP_STATE_SLAVE) ||
+            (state == D7ASP_STATE_SLAVE_PENDING_MASTER))
     {
-        switch_state(D7ASP_STATE_MASTER);
-        sched_post_task(&flush_fifos);
+        if (current_response_packet)
+        {
+            DPRINT("Discard the response since the response period is expired");
+            packet_queue_free_packet(current_response_packet);
+            current_response_packet = NULL;
+        }
+
+        if (state == D7ASP_STATE_SLAVE)
+            switch_state(D7ASP_STATE_IDLE);
+        else if(state == D7ASP_STATE_SLAVE_PENDING_MASTER)
+        {
+            switch_state(D7ASP_STATE_MASTER);
+            DPRINT("Schedule task to flush the fifo");
+            sched_post_task(&flush_fifos);
+        }
     }
 }

--- a/stack/modules/d7ap/d7asp.h
+++ b/stack/modules/d7ap/d7asp.h
@@ -108,7 +108,7 @@ typedef struct {
 
 void d7asp_init(d7asp_init_args_t* init_args);
 d7asp_queue_result_t d7asp_queue_alp_actions(d7asp_fifo_config_t* d7asp_fifo_config, uint8_t* alp_payload_buffer, uint8_t alp_payload_length); // TODO return status
-bool d7asp_process_received_packet(packet_t* packet);
+bool d7asp_process_received_packet(packet_t* packet, bool extension);
 
 /**
  * @brief Called by DLL to signal the packet has been transmitted

--- a/stack/modules/d7ap/d7atp.c
+++ b/stack/modules/d7ap/d7atp.c
@@ -289,7 +289,7 @@ void d7atp_respond_dialog(packet_t* packet)
 
     // modify the request headers and turn this into a response
     d7atp_ctrl_t* d7atp = &(packet->d7atp_ctrl);
-    d7atp->ctrl_is_start = 0;
+
     // leave ctrl_is_ack_requested as is, keep the requester value
     d7atp->ctrl_ack_not_void = false; // TODO
     d7atp->ctrl_ack_record = false; // TODO validate
@@ -393,6 +393,8 @@ void d7atp_signal_packet_csma_ca_insertion_completed(bool succeeded)
 
 void d7atp_process_received_packet(packet_t* packet)
 {
+    bool extension = false;
+
     assert(d7atp_state == D7ATP_STATE_MASTER_TRANSACTION_RESPONSE_PERIOD
             || d7atp_state == D7ATP_STATE_IDLE); // IDLE: when doing channel scanning outside of transaction
 
@@ -411,12 +413,24 @@ void d7atp_process_received_packet(packet_t* packet)
             return;
         }
 
-        // TODO assert(!packet->d7atp_ctrl.ctrl_is_start); // start dialog not allowed when in master transaction state
         if(packet->d7atp_ctrl.ctrl_is_start)
         {
-            DPRINT("Start dialog not allowed when in master transaction state, skipping segment");
-            packet_queue_free_packet(packet);
-            return;
+            // if this is the last transaction, it means that the extension procedure is initiated by the responder
+            if (packet->d7atp_ctrl.ctrl_is_stop)
+            {
+                DPRINT("Dialog terminated, we need to start a new dialog this time as a responder");
+                current_dialog_id = 0;
+                switch_state(D7ATP_STATE_IDLE);
+                d7atp_start_dialog_timeout_timer();
+                d7anp_start_responder_foreground_scan();
+                extension = true;
+            }
+            else
+            {
+                DPRINT("Start dialog not allowed when in master transaction state, skipping segment");
+                packet_queue_free_packet(packet);
+                return;
+            }
         }
     }
     else
@@ -492,5 +506,5 @@ void d7atp_process_received_packet(packet_t* packet)
         active_addressee_access_profile.subbands[0].channel_index_end = rx_channel.center_freq_index;
     }
 
-    d7asp_process_received_packet(packet);
+    d7asp_process_received_packet(packet, extension);
 }

--- a/stack/modules/d7ap/d7atp.h
+++ b/stack/modules/d7ap/d7atp.h
@@ -67,4 +67,7 @@ void d7atp_signal_packet_transmitted(packet_t* packet);
 void d7atp_signal_packet_csma_ca_insertion_completed(bool succeeded);
 void d7atp_signal_foreground_scan_expired();
 void d7atp_process_received_packet(packet_t* packet);
+void d7atp_signal_transaction_response_period_elapsed();
+bool d7atp_is_response_period_expired();
+void d7atp_cancel_response_period_timeout_handler();
 #endif /* D7ATP_H_ */

--- a/stack/modules/d7ap/d7atp.h
+++ b/stack/modules/d7ap/d7atp.h
@@ -70,4 +70,6 @@ void d7atp_process_received_packet(packet_t* packet);
 void d7atp_signal_transaction_response_period_elapsed();
 bool d7atp_is_response_period_expired();
 void d7atp_cancel_response_period_timeout_handler();
+void d7atp_signal_dialog_termination();
+void d7atp_start_dialog_timeout_timer();
 #endif /* D7ATP_H_ */

--- a/stack/modules/d7ap/dae.h
+++ b/stack/modules/d7ap/dae.h
@@ -60,6 +60,7 @@ typedef struct
     uint8_t transmission_timeout_period;  // Tc
     uint8_t _rfu;
     subband_t subbands[1]; // TODO only support 1 subband for now
+    uint8_t dialog_to;
 } dae_access_profile_t;
 
 #endif /* DAE_H_ */

--- a/stack/modules/d7ap/dll.c
+++ b/stack/modules/d7ap/dll.c
@@ -111,8 +111,13 @@ static void switch_state(dll_state_t next_state)
     switch(next_state)
     {
     case DLL_STATE_CSMA_CA_STARTED:
+        /*
+         * In case of extension, a request can follow the response, so the
+         * current state can be DLL_STATE_TX_FOREGROUND_COMPLETED
+         */
         assert(dll_state == DLL_STATE_IDLE || dll_state == DLL_STATE_SCAN_AUTOMATION
-               || dll_state == DLL_STATE_FOREGROUND_SCAN);
+               || dll_state == DLL_STATE_FOREGROUND_SCAN
+               || dll_state == DLL_STATE_TX_FOREGROUND_COMPLETED);
         dll_state = next_state;
         DPRINT("Switched to DLL_STATE_CSMA_CA_STARTED");
         break;

--- a/stack/modules/d7ap/dll.c
+++ b/stack/modules/d7ap/dll.c
@@ -139,7 +139,8 @@ static void switch_state(dll_state_t next_state)
         break;
     case DLL_STATE_IDLE:
         assert(dll_state == DLL_STATE_FOREGROUND_SCAN || dll_state == DLL_STATE_CCA_FAIL
-               || dll_state == DLL_STATE_TX_FOREGROUND_COMPLETED);
+               || dll_state == DLL_STATE_TX_FOREGROUND_COMPLETED
+               || dll_state == DLL_STATE_CSMA_CA_STARTED);
         dll_state = next_state;
         DPRINT("Switched to DLL_STATE_IDLE");
         break;
@@ -330,21 +331,23 @@ static void execute_csma_ca()
     //hw_radio_set_rx(NULL, NULL, NULL); // put radio in RX but disable callbacks to make sure we don't receive packets when in this state
                                         // TODO use correct rx cfg + it might be interesting to switch to idle first depending on calculated offset
     uint16_t tx_duration = calculate_tx_duration();
+    timer_tick_t Tc = CONVERT_TO_TI(current_access_profile->transmission_timeout_period);
     switch (dll_state)
     {
         case DLL_STATE_CSMA_CA_STARTED:
         {
-            dll_tca = current_access_profile->transmission_timeout_period - tx_duration; // TODO d7anp_timeout
+            dll_tca = Tc - tx_duration; // TODO d7anp_timeout
             dll_cca_started = timer_get_counter_value();
-            DPRINT("Tca= %i = %i - %i", dll_tca, current_access_profile->transmission_timeout_period, tx_duration);
+            DPRINT("Tca= %i = %i - %i", dll_tca, Tc, tx_duration);
 
             if (dll_tca <= 0)
             {
-                // TODO how to handle this? signal upper layer?
                 DPRINT("Tca negative, CCA failed");
-                assert(false);
-//				switch_state(DLL_STATE_CCA_FAIL);
-//				sched_post_task(&execute_csma_ca);
+                // Repeating this procedure is useless since Tca keeps the same value.
+                // Let the upper layer decide eventually to change the channel in order to get
+                // a chance a send this frame
+                switch_state(DLL_STATE_IDLE);
+                d7anp_signal_packet_csma_ca_insertion_completed(false);
                 break;
             }
 
@@ -512,7 +515,11 @@ void dll_execute_scan_automation()
 
         hw_radio_set_rx(&rx_cfg, &packet_received, NULL);
 
-        assert(current_access_profile->scan_automation_period == 0); // scan automation period, assuming 0 for now
+        /*
+         * As stated by the specification, if the scan type is set to foreground,
+         * the scan automation period (To) should be set to 0.
+         */
+        assert(current_access_profile->scan_automation_period == 0);
     }
     else
     {

--- a/stack/modules/d7ap/dll.h
+++ b/stack/modules/d7ap/dll.h
@@ -30,6 +30,7 @@
 #define OSS_7_DLL_H
 
 #include "hwradio.h"
+#include "math.h"
 
 #include "dae.h"
 
@@ -52,6 +53,8 @@ typedef struct
     };
     //uint8_t target_address[8]; // TODO assuming 8B UID for now
 } dll_header_t;
+
+#define CONVERT_TO_TI(timeout_ct) (pow(4, timeout_ct >> 5) * (timeout_ct & 0b11111))
 
 void dll_init();
 void dll_tx_frame(packet_t* packet, dae_access_profile_t* access_profile);

--- a/stack/modules/d7ap/packet.h
+++ b/stack/modules/d7ap/packet.h
@@ -37,6 +37,7 @@
  * as metadata parsed or generated while moving through the different layers */
 struct packet
 {
+    bool request;
     dll_header_t dll_header;
     uint8_t d7anp_timeout;
     d7anp_ctrl_t d7anp_ctrl;


### PR DESCRIPTION
The UART logging unveiled some timing issue when 2 devices are repeatedly transmitting requests.
Due to the latency introduced by the amount of UART logging, it may happen that the response is sent outside the response period and this outdated response causes the requester to reboot (the expiration of the foreground scan initiated by a received packet leads to an assertion when this packet is discarded).
Increasing the transmission timeout period parameter can prevent this timing issue but I propose here to comply more precisely with the specified requirements stating that the responders perform a DLL foreground scan outside the transaction periods. As a result, I propose to start a response period timeout timer once a request is received. Upon expiration of this timer, the transaction is considered complete and a foreground scan can be initiated to scan for subsequent requests, provided that the Dialog is still ongoing. This timer can also be used to check if the response period is not expired when transmitting the response.

In order to verify that this proposal is compatible with some missing features, I introduced the support of multiple transaction per dialog (with a dedicated Dialog timer) and I introduced the extension procedure which requires precisely to start a foreground scan as a responder for the dialog timeout.     