### PR TITLE
Fix missing PLATFORM_USE_VCOM in CMakeLists.txt PLATFORM_HEADER_DEFINE

### DIFF
--- a/stack/framework/hal/platforms/EZR32LG_WSTK6200A/CMakeLists.txt
+++ b/stack/framework/hal/platforms/EZR32LG_WSTK6200A/CMakeLists.txt
@@ -73,6 +73,7 @@ PLATFORM_HEADER_DEFINE(
          ${PLATFORM_PREFIX}_CONSOLE_BAUDRATE
   BOOL   ${PLATFORM_PREFIX}_DEBUGPINS
          PLATFORM_USE_USB_CDC
+		 PLATFORM_USE_VCOM
 )
 
 #Define the 'platform library'. Every platform must define a 'PLATFORM' object library


### PR DESCRIPTION
This change refers to the EZR32LG_WSTK6200A board.
When PLATFORM_USE_VCOM was checked, CMake did not add it to platform_defs.h because of the missing line