### PR TITLE
Fix assertion fail issue in configure_next_event()

### DIFF
--- a/stack/framework/components/timer/timer.c
+++ b/stack/framework/components/timer/timer.c
@@ -252,6 +252,8 @@ static void configure_next_event()
 {
     //this function should only be called from an atomic context
 	timer_tick_t next_fire_time;
+    timer_tick_t current_time = timer_get_counter_value();
+
     do
     {
 		//find the next event that has not yet passed, and schedule
@@ -261,7 +263,7 @@ static void configure_next_event()
 		if(NG(next_event) != NO_EVENT)
 		{
 			next_fire_time = NG(timers)[NG(next_event)].next_event;
-      if ( (((int32_t)next_fire_time) - ((int32_t)timer_get_counter_value()) - timer_info->min_delay_ticks) <= 0 )
+      if ( (((int32_t)next_fire_time) - ((int32_t)current_time) - timer_info->min_delay_ticks) <= 0 )
 			{
         DPRINT("will be late, sched immediately");
         sched_post_task_prio(NG(timers)[NG(next_event)].f, NG(timers)[NG(next_event)].priority, NG(timers)[NG(next_event)].arg);
@@ -269,7 +271,7 @@ static void configure_next_event()
 			}
 		}
     }
-    while(NG(next_event) != NO_EVENT && ( (((int32_t)next_fire_time) - ((int32_t)timer_get_counter_value())  - timer_info->min_delay_ticks) <= 0  ) );
+    while(NG(next_event) != NO_EVENT && ( (((int32_t)next_fire_time) - ((int32_t)current_time)  - timer_info->min_delay_ticks) <= 0  ) );
 
     //at this point NG(next_event) is eiter equal to NO_EVENT (no tasks left)
     //or we have the next event we can schedule
@@ -285,7 +287,7 @@ static void configure_next_event()
 		//latest overflow time, to counteract any delays in updating counter_offset
 		//(eg when we're scheduling an event from an interrupt and thereby delaying
 		//the updating of counter_offset)
-      timer_tick_t fire_delay = (next_fire_time - timer_get_counter_value());
+      timer_tick_t fire_delay = (next_fire_time - current_time);
 		//if the timer should fire in less ticks than supported by the HW timer --> schedule it
 		//(otherwise it is scheduled from timer_overflow when needed)
 		if(fire_delay < COUNTER_OVERFLOW_INCREASE)
@@ -295,7 +297,7 @@ static void configure_next_event()
 #ifndef NDEBUG	    
 			//check that we didn't try to schedule a timer in the past
 			//normally this shouldn't happen but it IS theoretically possible...
-      fire_delay = (next_fire_time - timer_get_counter_value() - timer_info->min_delay_ticks);
+      fire_delay = (next_fire_time - current_time - timer_info->min_delay_ticks);
 			//fire_delay should be in [0,COUNTER_OVERFLOW_INCREASE]. if this is not the case, it is because timer_get_counter() is
 			//now larger than next_fire_event, which means we 'missed' the event
 			assert(((int32_t)fire_delay) > 0);


### PR DESCRIPTION
issue:

> assertion "((int32_t)fire_delay) > 0" failed: file \
> "/.../dash7-ap-open-source-stack/stack/framework/components/timer/timer.c", \
> line 306, function: configure_next_event

The timer_get_counter_value() is increasing all the time cause it's
LPTIM hardware time. Every time we call it the result maybe increase.

solve:

Get timer_get_counter_value() value and use it through the whole
function.