### PR TITLE
Fix ACK template and VID usage

### DIFF
--- a/stack/modules/d7ap/d7atp.c
+++ b/stack/modules/d7ap/d7atp.c
@@ -442,7 +442,7 @@ uint8_t d7atp_assemble_packet_header(packet_t* packet, uint8_t* data_ptr)
     //TODO check if at least one Responder has set the ACK_REQ flag
     //TODO aggregate the Device IDs of the Responders that set their ACK_REQ flags.
     // Provide the Responder or Requester ACK template when requested
-    else if (packet->d7atp_ctrl.ctrl_is_ack_requested && packet->d7atp_ctrl.ctrl_ack_not_void)
+    if (packet->d7atp_ctrl.ctrl_is_ack_requested && packet->d7atp_ctrl.ctrl_ack_not_void)
     {
         // add Responder ACK template
         (*data_ptr) = packet->d7atp_transaction_id; data_ptr++; // transaction ID start


### PR DESCRIPTION
Trying Dash7 I think I found 2 bugs.

When configuring a sensor_push in SESSION_RESP_MODE_ON_ERR, the sender does not provide ACK_template in the D7ATP.
The ACK_template is expected by the receiver, and this causes a misunderstanding when dissasembling the frame. 2 bytes from ALP payload are used ACK_template.

The second case occurs when using VID.
When assembling a request, the sender read back the UID in the function d7anp_assemble_packet_header. This is bad since this overwrite the VID stored in address_id, the frame use the 2 first bytes if the UID as a VID.
