### PR TITLE
STM32L0 LPTIM bugfix: timer fires early

### DIFF
--- a/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
+++ b/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
@@ -199,7 +199,8 @@ error_t hw_timer_schedule(hwtimer_id_t timer_id, hwtimer_tick_t tick )
 
         target_after_overflow = (tick > 0) ? tick : 1;
         return SUCCESS;
-    }
+    } else
+        target_after_overflow = 0;
     #endif
 
     return do_schedule(tick);

--- a/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
+++ b/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
@@ -53,11 +53,19 @@ static timer_callback_t overflow_f = 0x0;
 static bool timer_inited = false;
 #if defined(STM32L0)
   static LPTIM_HandleTypeDef timer;
-  static bool cmp_reg_write_pending = false;
-  static bool ready_for_trigger = false;
+  static volatile bool cmp_reg_write_pending = false;
+  static volatile bool ready_for_trigger = false;
+
+  // Note: the STM32 LPTIM seems to trigger whenever time >= target.
+  // This means that scheduling a value past the overflow will not work
+  // correctly. As a workaround for this edge case, the target is stored
+  // here temporarily, then programmed into the hw timer on overflow.
+  static volatile hwtimer_tick_t target_after_overflow;
 #elif defined(STM32L1)
   static TIM_HandleTypeDef timer;
 #endif
+
+static error_t do_schedule(hwtimer_tick_t tick);
 
 // Sets up a timer to count at 1024 Hz, driven by the 32.768 kHz LSE
 // The timer is running continuously. On STM32L0 the LPTIM1 is used,
@@ -180,6 +188,25 @@ error_t hw_timer_schedule(hwtimer_id_t timer_id, hwtimer_tick_t tick )
  		return ESIZE;
  	if(!timer_inited)
  		return EOFF;
+
+    #if defined(STM32L0)
+    // NOTE: a tick < current_tick cannot be scheduled directly, as the
+    // LPTIM peripheral would fire immediately (LPTIM_CMP > LPTIM_CNT).
+    // As a workaround, the scheduling is done right after
+    // the next overflow (IRQ calls do_schedule()).
+    hwtimer_tick_t current_tick = hw_timer_getvalue(timer_id);
+    if(tick < current_tick) {
+
+        target_after_overflow = (tick > 0) ? tick : 1;
+        return SUCCESS;
+    }
+    #endif
+
+    return do_schedule(tick);
+}
+
+static error_t do_schedule(hwtimer_tick_t tick)
+{
   //don't enable the interrupt while waiting to write a new compare value
   ready_for_trigger = false;
   while(cmp_reg_write_pending); // prev write operation is pending, writing again before may give unpredicatable results (see datasheet), so block here
@@ -214,6 +241,7 @@ error_t hw_timer_cancel(hwtimer_id_t timer_id)
     __HAL_LPTIM_DISABLE_IT(&timer, LPTIM_IT_CMPM);
     __HAL_LPTIM_CLEAR_FLAG(&timer, LPTIM_IT_CMPM);
     ready_for_trigger = false;
+    target_after_overflow = 0;
 #elif defined(STM32L1)
     __HAL_TIM_DISABLE_IT(&timer, TIM_IT_CC1);
     __HAL_TIM_CLEAR_FLAG(&timer, TIM_IT_CC1);
@@ -302,6 +330,15 @@ void TIMER_ISR(void)
     if(__HAL_LPTIM_GET_IT_SOURCE(&timer, LPTIM_FLAG_ARRM) !=RESET)
     {
       __HAL_LPTIM_CLEAR_FLAG(&timer, LPTIM_IT_ARRM);
+
+      #if defined(STM32L0)
+      // workaround to schedule past the 0xFFFF overflow value
+      if(target_after_overflow) {
+        do_schedule(target_after_overflow);
+        target_after_overflow = 0;
+      }
+      #endif
+
       if(overflow_f != 0x0)
         overflow_f();
     }


### PR DESCRIPTION
The STM32L0 LPTIM peripheral appears to trigger a match interrupt
whenever LPTIM_CMP >= LPTIM_CNT. Not only of LPTIM_CMP == LPTIM_CNT.

In most cases this works just fine: a timer interrupt is scheduled for t_future > t_now.
As soon as the counter hits t_future, the interrupt is raised as
expected.

However, this timer is just 16-bits, overflowing every 64 seconds
(assuming f = 1024 Hz). It is inevitable that the condition `t_future < t_now happens`
will happen at some point. As an example, what if t_now is close to 65536 and
we want to schedule an interrupt 1000 ticks in the future?

This patch works around this problem by checking that the timer is always
programmed with a CMP > CNT. If the new CMP value is smaller than the
current CNT value, the scheduling is handled from the overflow
interrupt: as soon as the overflow triggers, CMP > CNT(=0) by
definition.